### PR TITLE
Change default listen address to 127.0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ PORT=8080 ./target/release/font_obfuscator
 | 变量 | 默认值 | 说明 |
 |------|--------|------|
 | `PORT` | `1323` | 服务监听端口 |
+| `LISTEN_ADDR` | `127.0.0.1` | 服务监听地址 |
 | `BASE_FONT_PATH` | `base-font/KaiGenGothicCN-Regular.ttf` | 基础字体文件路径 |
 
 ### API
@@ -171,6 +172,7 @@ PORT=8080 ./target/release/font_obfuscator
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PORT` | `1323` | Server listening port |
+| `LISTEN_ADDR` | `127.0.0.1` | Server listen address |
 | `BASE_FONT_PATH` | `base-font/KaiGenGothicCN-Regular.ttf` | Base font file path |
 
 ### API

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 # 构建
 cargo build --release
 
-# 运行（默认监听 0.0.0.0:1323）
+# 运行（默认监听 127.0.0.1:1323）
 ./target/release/font_obfuscator
 
 # 自定义端口
@@ -159,7 +159,7 @@ Built with Rust, using Google's [fontations](https://github.com/googlefonts/font
 # Build
 cargo build --release
 
-# Run (listens on 0.0.0.0:1323 by default)
+# Run (listens on 127.0.0.1:1323 by default)
 ./target/release/font_obfuscator
 
 # Custom port

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,7 @@ impl Default for FontConfig {
 #[derive(Clone)]
 pub struct AppConfig {
     pub port: u16,
+    pub listen_addr: String,
     pub font: FontConfig,
     pub base_font_path: String,
 }
@@ -35,6 +36,8 @@ impl AppConfig {
                 .ok()
                 .and_then(|p| p.parse().ok())
                 .unwrap_or(1323),
+            listen_addr: env::var("LISTEN_ADDR")
+                .unwrap_or_else(|_| "127.0.0.1".into()),
             font: FontConfig::default(),
             base_font_path: env::var("BASE_FONT_PATH")
                 .unwrap_or_else(|_| "base-font/KaiGenGothicCN-Regular.ttf".into()),

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,8 +36,7 @@ impl AppConfig {
                 .ok()
                 .and_then(|p| p.parse().ok())
                 .unwrap_or(1323),
-            listen_addr: env::var("LISTEN_ADDR")
-                .unwrap_or_else(|_| "127.0.0.1".into()),
+            listen_addr: env::var("LISTEN_ADDR").unwrap_or_else(|_| "127.0.0.1".into()),
             font: FontConfig::default(),
             base_font_path: env::var("BASE_FONT_PATH")
                 .unwrap_or_else(|_| "base-font/KaiGenGothicCN-Regular.ttf".into()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ async fn main() {
         })
     });
 
-    let addr = format!("0.0.0.0:{}", config.port);
+    let addr = format!("127.0.0.1:{}", config.port);
     tracing::info!("服务启动于 {}", addr);
 
     let state = Arc::new(AppState { config, font_data });

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ async fn main() {
         })
     });
 
-    let addr = format!("127.0.0.1:{}", config.port);
+    let addr = format!("{}:{}", config.listen_addr, config.port);
     tracing::info!("服务启动于 {}", addr);
 
     let state = Arc::new(AppState { config, font_data });


### PR DESCRIPTION
## Summary
- 将默认监听地址从 `0.0.0.0` 改为 `127.0.0.1`，仅监听本机，避免意外暴露服务到外部网络

## Test plan
- [x] 启动服务后确认只监听 127.0.0.1:1323
- [x] 确认本机请求正常工作

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复并将应用程序默认监听地址改为 127.0.0.1。

* **New Features**
  * 添加可配置的监听地址（通过 LISTEN_ADDR 环境变量），可自定义绑定主机。

* **Documentation**
  * 同步更新中英文快速开始和环境变量说明，示例改为默认监听 127.0.0.1。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->