### PR TITLE
Add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # font_obfuscator
 
+[![Rust](https://img.shields.io/badge/Rust-1.85+-DEA584?style=for-the-badge&logo=rust)](https://www.rust-lang.org/)
+[![CI](https://img.shields.io/github/actions/workflow/status/solarhell/font_obfuscator/ci.yml?branch=master&style=for-the-badge&logo=github&label=CI)](https://github.com/solarhell/font_obfuscator/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/License-MIT-blue?style=for-the-badge)](LICENSE)
+[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/solarhell/font_obfuscator?utm_source=oss&utm_medium=github&utm_campaign=solarhell%2Ffont_obfuscator&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews&style=for-the-badge)](https://coderabbit.ai)
+
 [中文](#中文) | [English](#english)
 
 ---


### PR DESCRIPTION
## Summary
- Add Rust version, CI status, License, and CodeRabbit review badges to README
- Badge style matches [go-tavily](https://github.com/solarhell/go-tavily) (`for-the-badge`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 在README中添加了四个新徽章，包括Rust版本、CI工作流状态、许可证和代码审查徽章，增强了项目文档的可视化呈现。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->