### PR TITLE
Update font dependencies: read-fonts 0.38.0, write-fonts 0.46.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,16 +8,16 @@ axum = "0.8.8"
 tokio = { version = "1.50.0", features = ["full"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-font-types = "0.11.0"
-read-fonts = "0.37.0"
-write-fonts = "0.45.0"
+font-types = "0.11.1"
+read-fonts = "0.38.0"
+write-fonts = "0.46.0"
 base64 = "0.22.1"
 uuid = { version = "1.22.0", features = ["v4"] }
 rand = "0.10.0"
 thiserror = "2.0.18"
 tower-http = { version = "0.6.8", features = ["cors"] }
 tracing = "0.1.44"
-tracing-subscriber = "0.3.22"
+tracing-subscriber = "0.3.23"
 ttf2woff2 = { version = "0.11.0", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary
- Upgrade `read-fonts` from 0.37.0 to 0.38.0
- Upgrade `write-fonts` from 0.45.0 to 0.46.0
- Upgrade `font-types` from 0.11.0 to 0.11.1
- Upgrade `tracing-subscriber` from 0.3.22 to 0.3.23

Both `read-fonts` and `write-fonts` must be upgraded together to avoid type mismatch errors caused by multiple versions of `read-fonts` in the dependency graph (fixes the CI failures in #288 and #289).

## Test plan
- [x] `cargo check` passes
- [x] All 47 tests pass
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 变更说明

* **维护工作**
  * 更新多个核心依赖库至最新版本，提升应用的稳定性和性能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->