### PR TITLE
Update dependencies and switch UUID to v7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,16 +4,16 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-axum = "0.8.8"
-tokio = { version = "1.50.0", features = ["full"] }
+axum = "0.8.9"
+tokio = { version = "1.52.1", features = ["full"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-font-types = "0.11.1"
-read-fonts = "0.38.0"
-write-fonts = "0.46.0"
+font-types = "0.11.3"
+read-fonts = "0.39.2"
+write-fonts = "0.48.1"
 base64 = "0.22.1"
-uuid = { version = "1.22.0", features = ["v4"] }
-rand = "0.10.0"
+uuid = { version = "1.23.1", features = ["v7"] }
+rand = "0.10.1"
 thiserror = "2.0.18"
 tower-http = { version = "0.6.8", features = ["cors"] }
 tracing = "0.1.44"

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ async fn encrypt(
     State(state): State<Arc<AppState>>,
     Json(req): Json<EncryptRequest>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let filename = uuid::Uuid::new_v4().to_string();
+    let filename = uuid::Uuid::now_v7().to_string();
     let output_dir = PathBuf::from("output");
 
     let obfuscate_result = if req.keep_all {
@@ -125,7 +125,7 @@ async fn encrypt_plus(
     State(state): State<Arc<AppState>>,
     Json(req): Json<EncryptPlusRequest>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let filename = uuid::Uuid::new_v4().to_string();
+    let filename = uuid::Uuid::now_v7().to_string();
     let output_dir = PathBuf::from("output");
 
     match crate::core::obfuscate_plus(


### PR DESCRIPTION
## Summary
- Bump axum 0.8.8 → 0.8.9, tokio 1.50.0 → 1.52.1
- Bump read-fonts 0.38.0 → 0.39.2, write-fonts 0.46.0 → 0.48.1, font-types 0.11.1 → 0.11.3
- Bump uuid 1.22.0 → 1.23.1, rand 0.10.0 → 0.10.1
- Switch UUID generation from v4 to v7 for time-ordered filenames

Supersedes #295 and #296.

## Test plan
- [x] cargo build
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test (47/47 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **杂项**
  * 升级多个依赖库至最新版本，提升系统稳定性与安全性
  * 优化了输出文件的唯一标识生成算法

<!-- end of auto-generated comment: release notes by coderabbit.ai -->