### PR TITLE
chore: update cargo manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,23 +2,39 @@
 name = "font_obfuscator"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.95"
 
 [dependencies]
 axum = "0.8.9"
-tokio = { version = "1.52.1", features = ["full"] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
-font-types = "0.11.3"
-read-fonts = "0.39.2"
-write-fonts = "0.48.1"
 base64 = "0.22.1"
-uuid = { version = "1.23.1", features = ["v7"] }
+font-types = "0.11.3"
 rand = "0.10.1"
+read-fonts = "0.39.2"
+serde = {
+    version = "1.0.228",
+    features = ["derive"],
+}
+serde_json = "1.0.149"
 thiserror = "2.0.18"
-tower-http = { version = "0.6.8", features = ["cors"] }
+tokio = {
+    version = "1.52.3",
+    features = ["full"],
+}
+tower-http = {
+    version = "0.6.10",
+    features = ["cors"],
+}
 tracing = "0.1.44"
 tracing-subscriber = "0.3.23"
-ttf2woff2 = { version = "0.11.0", default-features = false }
+ttf2woff2 = {
+    version = "0.11.1",
+    default-features = false,
+}
+uuid = {
+    version = "1.23.1",
+    features = ["v7"],
+}
+write-fonts = "0.48.1"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## Summary
- set the Cargo rust-version to 1.95
- format dependency entries with TOML 1.1 multiline inline tables
- upgrade tokio, tower-http, and ttf2woff2 patch versions

## Verification
- cargo metadata --no-deps --format-version 1
- cargo check
- cargo test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 变更说明

* **系统要求**
  * 设置最低Rust工具链版本为1.95

* **Chores**
  * 更新了多个依赖项版本，包括字体处理、网络通讯和格式转换等相关库

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/solarhell/font_obfuscator/pull/298)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->